### PR TITLE
Added use strict to devDbMethods_test file

### DIFF
--- a/test/devDbMethods_test.js
+++ b/test/devDbMethods_test.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const mongoose = require('mongoose');
 const chai = require('chai');
 const methods = require('../database/methods/devDbMethods');


### PR DESCRIPTION
Was going through the test files and noticed the file didn't have 'use strict'
